### PR TITLE
"0.154.13"

### DIFF
--- a/src/main/ModTheSpire.json
+++ b/src/main/ModTheSpire.json
@@ -4,7 +4,7 @@
   "author_list": ["Wiher154"],
   "description": "Play as powerful blood lord.... or what it was in the past... Now it's just formless lump of meat. Anyway, enjoy!",
   "credits": "Basemod and ModTheSpire guys",
-  "version": "0.154.12",
+  "version": "0.154.13",
   "sts_version": "12-20-2018",
   "mts_version": "3.27.0",
   "dependencies": ["basemod"],

--- a/src/main/java/BL/Cards/Skill/Uncommon/Madness.java
+++ b/src/main/java/BL/Cards/Skill/Uncommon/Madness.java
@@ -76,7 +76,8 @@ public class Madness extends CustomCard {
     public void triggerWhenDrawn() {
         if(((BLCharacter) AbstractDungeon.player).getMadnessTriggerperTurnCount() < MAX_MADNESS_PER_TURN_AMOUNT) {
             AbstractDungeon.actionManager.addCardQueueItem(new CardQueueItem(this, AbstractDungeon.getCurrRoom().monsters.getRandomMonster(true), this.energyOnUse, true, true), true);
-            ((BLCharacter) AbstractDungeon.player).addMadnessTriggerperTurnCount(1);
+            if(AbstractDungeon.player instanceof  BLCharacter)
+                ((BLCharacter) AbstractDungeon.player).addMadnessTriggerperTurnCount(1);
         }
     }
 }

--- a/src/main/java/BL/Powers/Blood.java
+++ b/src/main/java/BL/Powers/Blood.java
@@ -21,12 +21,14 @@ public class Blood extends AbstractPower {
         this.type = PowerType.BUFF;
         this.description = DESCRIPTION;
         this.img = new Texture(IMG_PATH);
-        ((BLCharacter) AbstractDungeon.player).addBloodGainedThisBattle(amount);
+        if(AbstractDungeon.player instanceof BLCharacter)
+            ((BLCharacter) AbstractDungeon.player).addBloodGainedThisBattle(amount);
     }
 
     public void stackPower(int stackAmount){
         this.amount += stackAmount;
-        ((BLCharacter) AbstractDungeon.player).addBloodGainedThisBattle(stackAmount);
+        if(AbstractDungeon.player instanceof BLCharacter)
+            ((BLCharacter) AbstractDungeon.player).addBloodGainedThisBattle(stackAmount);
         if (this.amount <= 0)
             this.addToTop(new RemoveSpecificPowerAction(this.owner, this.owner, POWER_ID));
     }

--- a/src/main/java/BL/Relics/CoreEssence.java
+++ b/src/main/java/BL/Relics/CoreEssence.java
@@ -59,7 +59,7 @@ public class CoreEssence extends CustomRelic {
     }
     public void onVictory(){
         super.onVictory();
-        if(this.counter < ESSENCE_NEEDED_AMOUNT)
+        if(this.counter < ESSENCE_NEEDED_AMOUNT && AbstractDungeon.player instanceof BLCharacter)
             this.counter += ((BLCharacter)AbstractDungeon.player).getBloodGainedThisBattle();
     }
 


### PR DESCRIPTION
===Changes===

===BugFixes===
Blood.java and Madness.java - now check if player is BLCharacter before few technical counts. That restricts core essence relic usage for other players and also make madness endless but opens up a lot of BL cards for other classes.
CoreEssence.java - same as up, it's just useless without BLCharacter.

===New===